### PR TITLE
criu: apply two patch to support c/r function

### DIFF
--- a/checkpoint.go
+++ b/checkpoint.go
@@ -118,7 +118,8 @@ var namespaceMapping = map[specs.LinuxNamespaceType]int{
 }
 
 func setEmptyNsMask(context *cli.Context, options *libcontainer.CriuOpts) error {
-	var nsmask int
+	/* Runc doesn't manage network devices and their configuration */
+	nsmask := unix.CLONE_NEWNET
 
 	for _, ns := range context.StringSlice("empty-ns") {
 		f, exists := namespaceMapping[specs.LinuxNamespaceType(ns)]

--- a/restore.go
+++ b/restore.go
@@ -97,6 +97,9 @@ using the runc checkpoint command.`,
 			return err
 		}
 		options := criuOptions(context)
+		if err := setEmptyNsMask(context, options); err != nil {
+			return err
+		}
 		status, err := startContainer(context, spec, CT_ACT_RESTORE, options)
 		if err != nil {
 			return err


### PR DESCRIPTION
Pick two patch from [opencontainer/runc] to [alibaba/runc] to support checkpoint/restore.
