### PR TITLE
cr: get pid from criu notify when restore(cherry-pick from master)

### DIFF
--- a/libcontainer/container_linux.go
+++ b/libcontainer/container_linux.go
@@ -1546,6 +1546,7 @@ func (c *linuxContainer) criuNotifications(resp *criurpc.CriuResp, process *Proc
 			if err != nil {
 				return nil
 			}
+			s.Pid = int(notify.GetPid())
 			for i, hook := range c.config.Hooks.Prestart {
 				if err := hook.Run(s); err != nil {
 					return newSystemErrorWithCausef(err, "running prestart hook %d", i)


### PR DESCRIPTION
when restore container from a checkpoint directory, we should get
pid from criu notify, since c.initProcess has not been created.

Signed-off-by: Ace-Tang <aceapril@126.com>

we need this patch or criu test in https://github.com/alibaba/pouch/pull/2516 will fail